### PR TITLE
Store .bliss in the app install folder

### DIFF
--- a/bliss/package_routines
+++ b/bliss/package_routines
@@ -109,8 +109,11 @@
 #PKG_MAIN_REMOVE="{
 #}"
 #
-#PKG_POST_REMOVE="{
-#}"
+PKG_POST_REMOVE="{
+  BLISS_WORKING_DIR="\${SYS_MULTIMEDIA_PATH}/../homes/admin/.bliss"
+  log "Will remove \$BLISS_WORKING_DIR"
+  rm -rf \$BLISS_WORKING_DIR 
+}"
 #
 ######################################################################
 # Define any package specific initialization that shall be performed
@@ -203,6 +206,13 @@ pkg_install(){
   /usr/local/jre/bin/java -jar ${SYS_QPKG_DIR}/install/${WGET_FILENAME} -options ${SYS_QPKG_DIR}/install/auto-install.properties 
   #rm ${SYS_QPKG_DIR}/install/auto-install.properties
   #rm ${SYS_QPKG_DIR}/install/${WGET_FILENAME}
+  
+  BLISS_WORKING_DIR="${SYS_MULTIMEDIA_PATH}/../homes/admin/.bliss"
+  #default settings
+  if [ ! -f ${BLISS_WORKING_DIR}/settings ]; then
+    mkdir -p ${BLISS_WORKING_DIR}
+    echo "musicLibrary=/share/Multimedia/" > ${BLISS_WORKING_DIR}/settings
+  fi
 
   log "Exit install"
 }

--- a/bliss/package_routines
+++ b/bliss/package_routines
@@ -207,7 +207,8 @@ pkg_install(){
   #rm ${SYS_QPKG_DIR}/install/auto-install.properties
   #rm ${SYS_QPKG_DIR}/install/${WGET_FILENAME}
   
-  BLISS_WORKING_DIR="${SYS_MULTIMEDIA_PATH}/../homes/admin/.bliss"
+  BLISS_WORKING_DIR="${SYS_QPKG_DIR}/.bliss"
+  log "BLISS_WORKING_DIR = ${BLISS_WORKING_DIR}"
   #default settings
   if [ ! -f ${BLISS_WORKING_DIR}/settings ]; then
     mkdir -p ${BLISS_WORKING_DIR}

--- a/bliss/package_routines
+++ b/bliss/package_routines
@@ -109,11 +109,8 @@
 #PKG_MAIN_REMOVE="{
 #}"
 #
-PKG_POST_REMOVE="{
-  BLISS_WORKING_DIR="\${SYS_MULTIMEDIA_PATH}/../homes/admin/.bliss"
-  log "Will remove \$BLISS_WORKING_DIR"
-  rm -rf \$BLISS_WORKING_DIR 
-}"
+#PKG_POST_REMOVE="{
+#}"
 #
 ######################################################################
 # Define any package specific initialization that shall be performed

--- a/bliss/shared/bliss-runner.sh
+++ b/bliss/shared/bliss-runner.sh
@@ -5,6 +5,7 @@ INSTALL_PATH=`/sbin/getcfg $QPKG_NAME Install_Path -f ${CONF}`
 BLISS_PID=/var/run/bliss.pid
 BLISS_PROC=bliss-splash
 CALLED_BY_APP=`cat /proc/$PPID/cmdline | xargs -0 echo | awk '{print $1}'`
+WORKING_DIR=$INSTALL_PATH/.bliss
 TMP_DIR=$INSTALL_PATH/tmp
 STDOUT_LOG=$TMP_DIR/stdout.log
 
@@ -112,7 +113,7 @@ case "$1" in
     mkdir -p $TMP_DIR
 
     # Set Bliss Temporary Files dir and launcher (needed for restart after updates)
-    export VMARGS=-Djava.io.tmpdir=${TMP_DIR}
+    export VMARGS="-Djava.io.tmpdir=${TMP_DIR} -Dbliss_working_directory=${INSTALL_PATH}"
     export BLISS_LAUNCHER_PROPERTY="-Dbliss.launcher=${INSTALL_PATH}/bliss-runner.sh"
 
     # Start the server


### PR DESCRIPTION
I found that in some QNAP devices, /shared/homes is not mapped to the main volumes. This means the space in those folders is very small, and the bliss database can soon fill up the space.

In this change, the working files are stored in the app install location.