### PR TITLE
Assume more limited version of grep, and don't tail -f the logs 

### DIFF
--- a/bliss/shared/bliss-runner.sh
+++ b/bliss/shared/bliss-runner.sh
@@ -134,10 +134,11 @@ case "$1" in
         exit 1
     fi
 
-    # Check stdout for the version number. This is a little dodgy! It only quits
-    # because there's content after the match. Couldn't find a better way to do it.
+    # Check stdout for the version number. This is a little dodgy! It probably only works
+    # because of the previous pause allowing the log file to populate. Couldn't find a better way to do it.
+    # Didn't want to do tail -f because of the possibility of hanging.
     # Prefer this to checking update files, which couples to the update mechanism.
-    VERSION=$(tail -f $STDOUT_LOG | grep -m1 -o "[0-9]\{8\}")
+    VERSION=$(head $STDOUT_LOG | grep "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]" | cut -d " " -f 3)
     /sbin/setcfg $QPKG_NAME Version $VERSION -f ${CONF}
     ;;
 


### PR DESCRIPTION
Tailing the logs can hang the startup.

Some older QNAP devices appear to have greps with very limited regex capability, so I simplified the regex. It was giving:

```
[/share/HDA_DATA/.qpkg/bliss] # qpkg_service start bliss
Process ID 21131
grep: invalid option -- m
BusyBox v1.01 (2017.09.04-18:33+0000) multi-call binary

Usage: grep [-ihHnqvs] PATTERN [FILEs...]
[etc]
```